### PR TITLE
Update InertiaForm to handle latest version inertia 0.4 and inertia-vue 0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "babel-preset-es2015": "^6.9.0"
     },
     "dependencies": {
-        "@inertiajs/inertia": "^0.1.7",
+        "@inertiajs/inertia": "^0.4.0",
         "prettier": "^1.10.2"
     }
 }

--- a/src/InertiaForm.js
+++ b/src/InertiaForm.js
@@ -149,12 +149,10 @@ class InertiaForm {
         }
 
         if (requestType === 'delete') {
-            return this.__inertia[requestType](url, options)
-                .then(then)
+            return this.__inertia[requestType](url, options, { onSuccess: (then) })
         }
 
-        return this.__inertia[requestType](url, this.hasFiles() ? objectToFormData(this.data()) : this.data(), options)
-            .then(then)
+        return this.__inertia[requestType](url, this.hasFiles() ? objectToFormData(this.data()) : this.data(), options, { onSuccess: (then) })
     }
 
     hasFiles() {
@@ -266,7 +264,7 @@ export default {
                         .withData(data)
                         .withOptions(options)
                         .withInertia(app.config.globalProperties.$inertia)
-                        .withPage(() => app.config.globalProperties.$page),
+                        .withPage(() => app.config.globalProperties.$page.hasOwnProperty("props") ? app.config.globalProperties.$page.props : app.config.globalProperties.$page),
             });
         } else {
             app.prototype.$inertia.form = (data = {}, options = {}) => {
@@ -274,7 +272,7 @@ export default {
                     .withData(data)
                     .withOptions(options)
                     .withInertia(app.prototype.$inertia)
-                    .withPage(() => app.prototype.$page);
+                    .withPage(() => app.prototype.$page.hasOwnProperty("props") ? app.prototype.$page.props : app.prototype.$page);
             };
         }
     },

--- a/src/InertiaForm.js
+++ b/src/InertiaForm.js
@@ -138,7 +138,7 @@ class InertiaForm {
         this.processing = true;
         this.successful = false;
 
-        const then = () => {
+        const onSuccess = page => {
             this.processing = false;
 
             if (! this.hasErrors()) {
@@ -146,15 +146,17 @@ class InertiaForm {
             } else {
                 this.onFail();
             }
+
+            if (options.onSuccess) {
+                options.onSuccess(page)
+            }
         }
 
         if (requestType === 'delete') {
-            return this.__inertia[requestType](url, options)
-                .then(then)
+            return this.__inertia[requestType](url, { ... options, onSuccess })
         }
 
-        return this.__inertia[requestType](url, this.hasFiles() ? objectToFormData(this.data()) : this.data(), options)
-            .then(then)
+        return this.__inertia[requestType](url, this.hasFiles() ? objectToFormData(this.data()) : this.data(), { ... options, onSuccess })
     }
 
     hasFiles() {
@@ -266,7 +268,7 @@ export default {
                         .withData(data)
                         .withOptions(options)
                         .withInertia(app.config.globalProperties.$inertia)
-                        .withPage(() => app.config.globalProperties.$page),
+                        .withPage(() => app.config.globalProperties.$page.hasOwnProperty('props') ? app.config.globalProperties.$page.props : app.config.globalProperties.$page),
             });
         } else {
             app.prototype.$inertia.form = (data = {}, options = {}) => {
@@ -274,7 +276,7 @@ export default {
                     .withData(data)
                     .withOptions(options)
                     .withInertia(app.prototype.$inertia)
-                    .withPage(() => app.prototype.$page);
+                    .withPage(() => app.prototype.$page.hasOwnProperty('props') ? app.prototype.$page.props : app.prototype.$page);
             };
         }
     },


### PR DESCRIPTION
This PR is related to https://github.com/laravel/jetstream-js/issues/7

I have updated the InertiaForm.js to handle the new breaking change of the `$page` object and deprecated promises as noted with these 2 updates:

$page.props breaking change: https://github.com/inertiajs/inertia/releases/tag/inertia-vue%40v0.3.0
Promise Deprecation: https://inertiajs.com/manual-visits#promise-deprecation

I have tested this with a new laravel jetstream install with the following new versions in package.json

```
"@inertiajs/inertia": "^0.4.0",
"@inertiajs/inertia-vue": "^0.3.0",
```

I had to do some refactoring of the AppLayout.vue file to test this as I had to change many reference from `$page` to `$page.props` in order to ensure things were working.


Thanks!