### PR TITLE
Add method to check error for specific field

### DIFF
--- a/src/InertiaForm.js
+++ b/src/InertiaForm.js
@@ -222,14 +222,16 @@ class InertiaForm {
                Object.keys(this.inertiaPage().errorBags[this.__options.bag]).length > 0;
     }
 
-    error(field) {
-        if (! this.hasErrors() ||
-            ! this.inertiaPage().errorBags[this.__options.bag][field] ||
-            this.inertiaPage().errorBags[this.__options.bag][field].length == 0) {
-            return;
-        }
+    hasError(field) {
+        return this.hasErrors() &&
+               this.inertiaPage().errorBags[this.__options.bag][field] &&
+               this.inertiaPage().errorBags[this.__options.bag][field].length > 0;
+    }
 
-        return this.inertiaPage().errorBags[this.__options.bag][field][0];
+    error(field) {
+        if (this.hasError(field)) {
+            return this.inertiaPage().errorBags[this.__options.bag][field][0];
+        }
     }
 
     errors(field = null) {
@@ -240,7 +242,7 @@ class InertiaForm {
                         : [];
         }
 
-        return this.error(field)
+        return this.hasError(field)
                     ? this.inertiaPage().errorBags[this.__options.bag][field]
                     : [];
     }


### PR DESCRIPTION
This PR related to issue #10 .

This method allow you to check error for the specific field. Useful when combining it with Vuetify.

Usage example in Vuetify:
```
<v-text-field
  label="Name"
  v-model="form.name"
  :error="form.hasError('name')"
  :error-messages="form.error('name')"
></v-text-field>
```

I've tested this method in the following versions
```
"@inertiajs/inertia": "^0.4.0",
"@inertiajs/inertia-vue": "^0.3.0",
"vuetify": "^2.3.14"
```

any suggestion is welcome